### PR TITLE
Posts!

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 url: http://hacksoc.org/
+paginate: 3

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,13 @@
+---
+layout: wrapper
+---
+
+<h2>{{ page.title }}</h2>
+
+<div class="date">
+  {{ page.date | date_to_string }}  
+</div>
+
+<div class="post-text">
+  {{ content }}  
+</div>

--- a/_local_config.yml
+++ b/_local_config.yml
@@ -1,0 +1,2 @@
+url: http://localhost:4000/
+paginate: 3

--- a/_posts/2014-01-20-website-changes.md
+++ b/_posts/2014-01-20-website-changes.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title: Website Changes
+---
+
+You may have noticed that the website now looks subtly different.
+
+It is now easier for us to create posts relating to stuff.
+
+Yes, this is essentially just a test post.

--- a/index.html
+++ b/index.html
@@ -11,6 +11,50 @@ layout: wrapper
   <a href="https://www.google.com/calendar/embed?src=hack@yusu.org&ctz=Europe/London">html</a>
 </p>
 
+<div class="posts">
+
+  <div class="posts-list">
+    {% for post in paginator.posts %}
+      <div class="post-entry">
+        <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
+        <div class="post-date">{{ post.date | date_to_string }}</div>
+        <div class="post-excerpt">
+          {{ post.excerpt }}
+        </div>
+      </div>
+    {% endfor %}
+  </div>
+
+  <div class="pagination">
+    {% if paginator.total_pages > 1 %}
+      <div class="pagination">
+        {% if paginator.previous_page %}
+          <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}">&laquo; Newer</a>
+        {% else %}
+          <span>&laquo; Newer</span>
+        {% endif %}
+
+        {% for page in (1..paginator.total_pages) %}
+          {% if page == paginator.page %}
+            <em>{{ page }}</em>
+          {% elsif page == 1 %}
+            <a href="{{ '/index.html' | prepend: site.baseurl | replace: '//', '/' }}">{{ page }}</a>
+          {% else %}
+            <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}">{{ page }}</a>
+          {% endif %}
+        {% endfor %}
+
+        {% if paginator.next_page %}
+          <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}">Older &raquo;</a>
+        {% else %}
+          <span>Older &raquo;</span>
+        {% endif %}
+      </div>
+    {% endif %}
+  </div>
+</div>
+
+
 <div class="infobox">
   <h2>Weekly Talks</h2>
   <p>Talks on mostly-technical topics of mostly-general interest.</p>

--- a/style.css
+++ b/style.css
@@ -36,7 +36,6 @@ nav ul li a { border: 1px solid #fff; display: block; padding: 0.75em 0.5em }
 nav ul li a:hover { border: 1px solid #ddd; position: relative; top: -6px }
 
 #main { padding: 10px 50px 20px 50px; }
-#main h2 { margin: 15px 0 0 0; }
 
 a:link, a:visited {color: #0A5D99; text-decoration: none;}
 a:active, a:hover {color: #609B11; text-decoration: underline;}
@@ -63,5 +62,9 @@ article header { padding: 0 0 6px 0 }
 p.nothing { font-style: italic }
 p.meta { font-size: 0.8em }
 
-.infobox { width: 66%; clear: both; margin-bottom: 32px; /*border: 1px solid #000*/ }
+.infobox { width: 66%; clear: both; margin-top: 15px; margin-bottom: 32px; /*border: 1px solid #000*/ }
 .alternate { float: right; text-align: right }
+
+.posts { padding-bottom: 12px; border-bottom: 1px solid black }
+.post-entry { margin-top: 3px }
+.posts-list { padding-bottom: 12px }


### PR DESCRIPTION
A bunch of changes to make more space on the homepage, and then a stream of posts in the space freed up.
- Calendar is now agenda display to make more room on the homepage (also IMO it's more readable).
- Summary boxes have been removed, because half of them were "nothing here", and to make more room
- Pub quiz and competition have lost their infoboxes because they're one-off.
- Weekly talks have acquired an (uninformative) infobox

We now have a stream of posts (in an entirely coventional Jekyll way). These will display the first paragraph as a preview, and paginate after 3 posts.

There is also now a file `_local_config.yml` to give to `jekyll serve`, as there seems to be no sensible way of overriding jekyll's `url` parameter on the command line.
