### PR TITLE
Infer news dates from filenames.

### DIFF
--- a/hakyll.hs
+++ b/hakyll.hs
@@ -21,8 +21,8 @@ main = hakyllWith defaultConfiguration $ do
     route $ setExtension ".html"
     compile $ pandocCompiler
       >>= saveSnapshot "content"
-      >>= loadAndApplyTemplate "templates/news.html"    defaultContext
-      >>= loadAndApplyTemplate "templates/wrapper.html" defaultContext
+      >>= loadAndApplyTemplate "templates/news.html"    postContext
+      >>= loadAndApplyTemplate "templates/wrapper.html" postContext
       >>= relativizeUrls
 
   -- Build index page with paginated news list
@@ -36,7 +36,7 @@ main = hakyllWith defaultConfiguration $ do
       entries <- recentFirst =<< loadAll pattern
       let ctx = dropField "title" $
             paginateContext paginator pageNum <>
-            listField "entries" (excerptField "content" <> defaultContext) (return entries) <>
+            listField "entries" (excerptField "content" <> postContext) (return entries) <>
             defaultContext
       makeItem ""
         >>= loadAndApplyTemplate "templates/newslist.html" ctx
@@ -49,6 +49,10 @@ main = hakyllWith defaultConfiguration $ do
     compile $ pandocCompiler
       >>= loadAndApplyTemplate "templates/wrapper.html" defaultContext
       >>= relativizeUrls
+
+-- | Context for rendering posts: infer the date from the filename.
+postContext :: Context String
+postContext = dateField "date" "%B %e, %Y" <> defaultContext
 
 -- | Extract the first non-blank line from a news post.
 excerptField :: Snapshot -> Context String

--- a/news/2014-01-20-bytemark-sponsorship.md
+++ b/news/2014-01-20-bytemark-sponsorship.md
@@ -1,6 +1,5 @@
 ---
 title: HackSoc Sponsored by Bytemark
-date: 2014-01-20 18:00:00 +0000
 ---
 
 As you may know, over the Christmas break, [Bytemark][] very kindly

--- a/news/2014-01-20-website-changes.md
+++ b/news/2014-01-20-website-changes.md
@@ -1,6 +1,5 @@
 ---
 title: Website Changes
-date: 2014-01-20
 ---
 
 You may have noticed that the website now looks subtly different.

--- a/news/2014-01-22-agm.md
+++ b/news/2014-01-22-agm.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Week 5
-date: 2014-01-22 00:00:00 +0000
 ---
 
 As you may know, this term we are having our AGM! We need to hold

--- a/news/2014-01-29-agm-update.md
+++ b/news/2014-01-29-agm-update.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Update
-date: 2014-01-29 00:00:00 +0000
 ---
 
 **The AGM will be held on Friday the 7th of February, at 19:30, in

--- a/news/2014-02-08-agm-results.md
+++ b/news/2014-02-08-agm-results.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Results
-date: 2014-02-08 00:00:00 +0000
 ---
 
 Same bat-committee, same bat-society.

--- a/news/2014-11-14-mini-game-jame.md
+++ b/news/2014-11-14-mini-game-jame.md
@@ -1,6 +1,5 @@
 ---
 title: Mini Game Jam
-date: 2014-11-14 18:12:00 +0000
 ---
 
 

--- a/news/2015-02-26-agm-results.md
+++ b/news/2015-02-26-agm-results.md
@@ -1,6 +1,5 @@
 ---
 title: AGM results
-date: 2015-02-26 00:00:00 +0000
 ---
 
 The committee is dead, long live the committee!

--- a/news/2015-07-31-egm-results.md
+++ b/news/2015-07-31-egm-results.md
@@ -1,6 +1,5 @@
 ---
 title: EGM results
-date: 2015-07-31 00:00:00 +0000
 ---
 
 Congratulations to Oliver Downard who is our new secretary, replacing Michael Mokrysz! He was voted in with 6 votes, 3 abstentions and 1 vote for re-open nominations!

--- a/news/2016-02-07-agm.md
+++ b/news/2016-02-07-agm.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Week 7
-date: 2016-02-7 00:00:00 +0000
 ---
 
 Coming up later this term is our Annual General Meeting (AGM), when we elect 

--- a/news/2016-02-21-agm-results.md
+++ b/news/2016-02-21-agm-results.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Results
-date: 2016-02-21
 ---
 
 We held the AGM on Friday, and have a new committee! We'll be having a

--- a/news/2017-01-16-workshop.md
+++ b/news/2017-01-16-workshop.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction to Programming Workshop
-date: 2017-01-16
 ---
 
 Have you ever considered giving coding a try? The society for Computer Science, HackSoc, is hosting an introductory workshop on Python programming for beginners as part of the YUSU Give It A Go week, with no experience required.

--- a/news/2017-02-05-agm.md
+++ b/news/2017-02-05-agm.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Week 8
-date: 2017-02-05 00:00:00 +0000
 ---
 
 Coming up later this term is our Annual General Meeting (AGM), when we elect a brand new committee to be in charge of the society's day-to-day operations. This is your opportunity to run for a committee position, and take charge. 

--- a/news/2017-03-03-agm-results.md
+++ b/news/2017-03-03-agm-results.md
@@ -1,6 +1,5 @@
 ---
 title: AGM Results 2017!
-date: 2017-03-03
 ---
 
 After an exciting committee election at the AGM, we have elected a new committee of HackSoc!


### PR DESCRIPTION
Hakyll can infer the dates of entries from the filenames, if I tell it to. Which I did.

This renders #52 totally obsolete.