### PR TITLE
Performance / A11Y Improvements

### DIFF
--- a/static/style_2017.css
+++ b/static/style_2017.css
@@ -5,16 +5,16 @@ cite,code { font-style:normal; font-weight:normal; }
 h1,h2 { font-size:100%; font-weight:normal; }
 /* end normalize*/
 
-h2 { font-family: 'Sanchez', serif; margin-top: 16px; color: var(--heading-color); font-size: 2em }
+h2 { font-family: 'Sanchez', serif; font-display: swap; margin-top: 16px; color: var(--heading-color); font-size: 2em }
 
-span.maintitle{font-family:roboto_slabregular;color: var(--logo-text-color);line-height:1;}
+span.maintitle{font-family:roboto_slabregular; font-display: block; color: var(--logo-text-color);line-height:1;}
 span.largetitle{font-size:7em;}
 span.subtitle{font-size:2em;padding-left:5px;}
 span.subtitle .highlight{color: var(--logo-emphasis-color);}
 a.maintitle:hover{text-decoration:none;}
 
 p { padding: 5px 5px 5px 20px; line-height: 23px; }
-body { font-family: 'Bitstream Vera Sans', sans-serif; font-size: 14px; color: var(--text-color); background-color: var(--background-color); }
+body { font-family: 'Bitstream Vera Sans', sans-serif; font-display: swap; font-size: 14px; color: var(--text-color); background-color: var(--background-color); }
 
 ul, ol { margin-left:4em; }
 li { padding:0.2em;}
@@ -37,7 +37,7 @@ a:active, a:hover {color: var(--emphasis-color); text-decoration: underline;}
 iframe { display: block; margin: 0 auto }
 
 blockquote header { padding: 0; border: 0; text-align: left; font-size: 14px;}
-blockquote h2 { font-family: 'Bistream Vera Sans', sans-serif; font-weight: bold; font-size: 14px; display: inline; padding: 0; margin: 0;}
+blockquote h2 { font-family: 'Bistream Vera Sans', sans-serif; font-display: swap; font-weight: bold; font-size: 14px; display: inline; padding: 0; margin: 0;}
 blockquote .aside { font-style: italic; font-size: 0.8em; margin-bottom: 1em;}
 cite { font-style: italic; }
 
@@ -57,7 +57,7 @@ dd { margin-left: 2em }
 .entries, .entries li { list-style-type: none; margin-left: 0.5em; padding-left: 0 }
 .entries a { font-weight: bold }
 .entries p { margin-left: 0; padding-left: 0 }
-.meta { font-style: italic; font-size: 0.8em; color: #777 }
+.meta { font-style: italic; font-size: 0.8em; color: #555 }
 .pages { list-style-type: none; margin-left: 0; padding-left: 0 }
 .pages li { display: inline }
 .pages li.active { font-weight: bold }
@@ -69,7 +69,7 @@ body > #container { height: auto; min-height: 100%; }
 footer { clear: both; position: relative; height: 3em; margin-top: -3em; padding: 0 32px }
 footer h2 { font-size: 1em }
 
-code { font-family: Inconsolata, monospace; font-size: 13px }
+code { font-family: Inconsolata, monospace; font-display: swap; font-size: 13px }
 .noticebox { padding: 1em; margin: 0 10em; border: 1px solid var(--de-emphasis-color); background-color: #dfc9bc; text-align: center }
 
 .important { text-align: center; font-weight: bold; }
@@ -122,7 +122,8 @@ h1.titleheading{
 }
 @media screen and (max-width: 700px) {
     /* Stop alternating the infoboxes below 700px, just centre align them */
-    .infobox{width:100%;text-align:center}
+    .infobox:nth-child(odd), .infobox {width:100%;text-align:center;} 
+    /* overly verbose selector because cascading isn't working properly */
     .infobox >p{padding:5px 5px 5px 5px;}
     h2{width:100%;text-align:center;font-size:1.4em;}
 }

--- a/static/style_2017.css
+++ b/static/style_2017.css
@@ -50,7 +50,7 @@ dd { margin-left: 2em }
 #server_list a:last-child::after { content: "" }
 
 .infobox { width: 630px; clear: both; margin-top: 15px; margin-bottom: 32px; /*border: 1px solid #000*/ }
-.infobox:nth-child(odd) {float: right; text-align: right}
+.infobox:nth-child(even) {float: right; text-align: right}
 .infobox h2 { margin-top: 0 }
 
 #posts { padding-bottom: 12px; border-bottom: 1px solid black }

--- a/static/style_2017.css
+++ b/static/style_2017.css
@@ -7,7 +7,7 @@ h1,h2 { font-size:100%; font-weight:normal; }
 
 h2 { font-family: 'Sanchez', serif; font-display: swap; margin-top: 16px; color: var(--heading-color); font-size: 2em }
 
-span.maintitle{font-family:roboto_slabregular; font-display: block; color: var(--logo-text-color);line-height:1;}
+span.maintitle{font-family:roboto_slabregular; font-display: swap; color: var(--logo-text-color);line-height:1;}
 span.largetitle{font-size:7em;}
 span.subtitle{font-size:2em;padding-left:5px;}
 span.subtitle .highlight{color: var(--logo-emphasis-color);}

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -1,4 +1,4 @@
-<iframe id="calendar" src="https://calendar.google.com/calendar/embed?title=HackSoc%20Events&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;height=600&amp;wkst=2&amp;bgcolor=%23f3f2f4&amp;src=yusu.org_h8uou2ovt1c6gg87q5g758tsvs%40group.calendar.google.com&amp;color=%23212121&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
+<iframe id="calendar" title="HackSoc Events" src="https://calendar.google.com/calendar/embed?title=HackSoc%20Events&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;height=600&amp;wkst=2&amp;bgcolor=%23f3f2f4&amp;src=yusu.org_h8uou2ovt1c6gg87q5g758tsvs%40group.calendar.google.com&amp;color=%23212121&amp;ctz=Europe%2FLondon" style=" border-width:0 " width="900" height="600" frameborder="0" scrolling="no"></iframe>
 
 <p id="calendar_links">
   <strong>Subscribe:</strong>

--- a/templates/server.handlebars
+++ b/templates/server.handlebars
@@ -1,6 +1,6 @@
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
 

--- a/templates/wrapper.handlebars
+++ b/templates/wrapper.handlebars
@@ -5,10 +5,12 @@
 {{#if builddate}}Built on {{builddate}}{{/if}}
   -->
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    {{!-- having maxiumum-scale 1.0 here disables pinch-zoom, which fails an a11y audit--}}
+    <meta name="theme-color" content="#443752"/>
 
     <title>
         {{#if title}}{{title}} &ndash; {{/if}}HackSoc &ndash; the computer science society
@@ -59,7 +61,9 @@
 
       </header>
 
+    <main>
      {{{body}}}
+    </main>
 
       <div id="stupid-end-marker"></div>
     </div>


### PR DESCRIPTION
This PR brings a lot of small improvements that make the site more accessible. While there is probably more that could be done, these are some low-hanging fruit that are easy to fix.

My main concern is being sure that this won't affect the normal experience of the site. The two changes that I think might have an effect are:
 - Removing `maximum-scale=1.0` from the meta viewport tag in `wrapper.handlebars`
 - Wrapping `{{{body}}}` in a `<main>` element

This version of the site is live on https://beta.hacksoc.org

(When merged I'd suggest a squash-and-merge)