### PR TITLE
Note that memberships are not currently available to purchase online

### DIFF
--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -9,7 +9,7 @@
 <div class="important">
   <h2>Sign Up</h2>
   <p><a href="https://forms.gle/w3ptCJ1tS64oDhvh9">Subscribe to the mailing list</a></p>
-  <p>Pay in person or <a href="http://www.yusu.org/opportunities/societies/hacksoc">online</a>. All events are open to non-members too!</p>
+  <p>Pay in person <del>or <a href="http://www.yusu.org/opportunities/societies/hacksoc">online</a></del> (currently unavailable while YUSU upgrades their website). All events are open to non-members too!</p>
 </div>
 
 {{{newslist}}}


### PR DESCRIPTION
YUSU says:

> We are currently in the process of massively upgrading our online management systems for the website, which is pretty exciting. … It also means that society memberships are currently not purchasable online.

The page we're currently linking to is a big 404, which doesn't look great:

![image of yusu.org, displaying a "404 not found" error](https://user-images.githubusercontent.com/9433472/63129559-b8ac6a80-bfaf-11e9-9217-4fcc326d32e9.png)