### PR TITLE
Replace mailing list instructions

### DIFF
--- a/regular/about.html
+++ b/regular/about.html
@@ -23,7 +23,7 @@ title: About Us
   <dd><a href="mailto:hack@yusu.org">hack@yusu.org</a></dd>
 
   <dt>Email (Mailing List)</dt>
-  <dd><a href="mailto:hacksoc-list+subscribe@yusu.org">hacksoc-list+subscribe@yusu.org</a></dd>
+  <dd><a href="https://forms.gle/w3ptCJ1tS64oDhvh9">Subscribe</a></dd>
 
   <dt>Slack</dt>
   <dd><a href="https://hacksoc-york.slack.com">Join our Slack</a> with your york.ac.uk address</dd>

--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -8,7 +8,7 @@
 
 <div class="important">
   <h2>Sign Up</h2>
-  <p>Email <a href="mailto:hacksoc-list+subscribe@yusu.org">hacksoc-list+subscribe@yusu.org</a> OR visit <a href="https://groups.google.com/a/yusu.org/forum/#!forum/hacksoc-list">Google Groups</a> for the mailing list.</p>
+  <p><a href="https://forms.gle/w3ptCJ1tS64oDhvh9">Subscribe to the mailing list</a></p>
   <p>Pay in person or <a href="http://www.yusu.org/opportunities/societies/hacksoc">online</a>. All events are open to non-members too!</p>
 </div>
 


### PR DESCRIPTION
Google Groups is no longer used for the mailing list, so link to a Google Form where people can sign up instead.

Closes #72.