### PR TITLE
Updated link to point to new YUSU page for HackSoc and removed strikethrough.

### DIFF
--- a/templates/index.handlebars
+++ b/templates/index.handlebars
@@ -9,7 +9,7 @@
 <div class="important">
   <h2>Sign Up</h2>
   <p><a href="https://forms.gle/w3ptCJ1tS64oDhvh9">Subscribe to the mailing list</a></p>
-  <p>Pay in person <del>or <a href="http://www.yusu.org/opportunities/societies/hacksoc">online</a></del> (currently unavailable while YUSU upgrades their website). All events are open to non-members too!</p>
+  <p>Pay in person or <a href="https://yusu.org/activities/view/hacksoc">online</a>. All events are open to non-members too!</p>
 </div>
 
 {{{newslist}}}


### PR DESCRIPTION
- Removed note about YUSU site being unable to accept payments.
- Removed strikethrough of YUSU site link.
- Update YUSU site link to match new location.