### PR TITLE
Add Discord invite to irc.html

### DIFF
--- a/regular/irc.html
+++ b/regular/irc.html
@@ -11,9 +11,11 @@ title: IRC
   (<strong>#hacksoc</strong> on <strong>irc.freenode.net</strong>)</p>
   <p>There is also the #cs-york channel, also <a href="http://webchat.freenode.net?channels=cs-york">on freenode</a>. This is not hacksoc's channel, but it is a great place to chat about CS stuff. Many hacksoc members also hang around there.
   (<strong>#cs-york</strong> on <strong>irc.freenode.net</strong>)</p>
+  <h3>Discord</h3>
+  <p>We also have a Discord server, used mostly for events, but a small number of channels are bridged from Slack. You can join using <a href="https://discord.gg/BFJDdyU">this link</a>.</p>
 </div>
 
-<p>Our chat system of choice is Slack. It's easy to use, fully-featured and modern. But we have kept the option of using IRC by connecting our Slack channel to our freenode channel.</p>
+<p>Our chat system of choice is Slack. It's easy to use, fully-featured and modern. However, we've kept the option of using IRC by connecting our Slack channel to our freenode channel, and we have a Discord server set up in a similar way. Note that, whilst a couple of channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Slack</strong>.</p>
 <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
 <ol>
@@ -25,6 +27,8 @@ title: IRC
 
   <li>You can change your name with <code>/nick new_name</code>, and join a new channel with <code>/join #channel_name</code></li>
 </ol>
+
+<p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in #gaming in Slack).</p>
 
 <h2>Code of Conduct:</h2>
 <ol>

--- a/regular/irc.html
+++ b/regular/irc.html
@@ -28,7 +28,7 @@ title: IRC
   <li>You can change your name with <code>/nick new_name</code>, and join a new channel with <code>/join #channel_name</code></li>
 </ol>
 
-<p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in #gaming in Slack).</p>
+<p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in the topic of #general in Slack).</p>
 
 <h2>Code of Conduct:</h2>
 <ol>

--- a/regular/irc.html
+++ b/regular/irc.html
@@ -9,8 +9,6 @@ title: Slack and IRC
   <h3>IRC</h3>
   <p>We have an IRC channel, connected to Slack. You can join the chat using freenode <a href="http://webchat.freenode.net?channels=hacksoc">web chat</a>
   (<strong>#hacksoc</strong> on <strong>irc.freenode.net</strong>)</p>
-  <p>There is also the #cs-york channel, also <a href="http://webchat.freenode.net?channels=cs-york">on freenode</a>. This is not hacksoc's channel, but it is a great place to chat about CS stuff. Many hacksoc members also hang around there.
-  (<strong>#cs-york</strong> on <strong>irc.freenode.net</strong>)</p>
   <h3>Discord</h3>
   <p>We also have a Discord server, used mostly for events, but a small number of channels are bridged from Slack. You can join using <a href="https://discord.gg/BFJDdyU">this link</a>.</p>
 </div>
@@ -27,6 +25,8 @@ title: Slack and IRC
 
   <li>You can change your name with <code>/nick new_name</code>, and join a new channel with <code>/join #channel_name</code></li>
 </ol>
+
+<p>There is also the #cs-york channel, also <a href="http://webchat.freenode.net?channels=cs-york">on freenode</a>. This is not HackSoc's channel, but it is a great place to chat about CS stuff. Many HackSoc members also hang around there.</p>
 
 <p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in the topic of #general in Slack).</p>
 

--- a/regular/irc.html
+++ b/regular/irc.html
@@ -1,5 +1,5 @@
 ---
-title: IRC
+title: Slack and IRC
 ---
 
 <div class="noticebox">


### PR DESCRIPTION
Several freshers (amongst others) have mentioned that Slack doesn't work well for them. It seems like it's probably worth advertising that we have a Discord server for those that don't want to use Slack.

I'm open to changes to the wording. I'm also not really happy with the layout, the noticebox feels too big:

![image](https://user-images.githubusercontent.com/9433472/97121807-f0b54e80-1718-11eb-92ac-54a3fad47490.png)