### PR TITLE
Make links in event descriptions the right colour

### DIFF
--- a/static/calendar.css
+++ b/static/calendar.css
@@ -91,6 +91,10 @@
     color: var(--text-color);
 }
 
+#calendar table td #calendar-info-description a {
+    color: var(--emphasis-color);
+}
+
 #calendar table td.disabled       { background-color: var(--cal-cell-disabled); }
 #calendar table td.today          { background-color: var(--cal-cell-today); }
 #calendar table td.today.disabled { background-color: var(--cal-cell-today-disabled); }


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/9433472/110153301-c6685180-7dda-11eb-8142-7995b4fe05ee.png)

After:

![image](https://user-images.githubusercontent.com/9433472/110153317-cb2d0580-7dda-11eb-8f3f-758a3bd5b922.png)