### PR TITLE
Style links in the calendar the same as everywhere else

### DIFF
--- a/static/calendar.css
+++ b/static/calendar.css
@@ -86,13 +86,9 @@
     display: none;
 }
 
-#calendar table td a {
+#calendar table td a.event-link {
     text-decoration: none;
     color: var(--text-color);
-}
-
-#calendar table td #calendar-info-description a {
-    color: var(--emphasis-color);
 }
 
 #calendar table td.disabled       { background-color: var(--cal-cell-disabled); }

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -145,6 +145,7 @@ async function loadCalendar(year, month) {
                 const link = document.createElement("a");
                 link.innerHTML = `<b>${event.when_human.start_time}</b> <br class="time-sep" />${event.summary}`;
                 link.href = "#";
+                link.className = "event-link";
                 link.onclick = (e) => {
                     e.preventDefault();
                     displayInfoPanel(link, event);


### PR DESCRIPTION
See also 7d7d19472 – now, instead of overriding the overridden style in order to reapply the global styling, we just more narrowly scope the override for the event times and titles.

In particular, this fixes the text-decoration property so that links in calendar event descriptions are underlined on hover, like links elsewhere on the website.