### PR TITLE
Add calendar button to join Google Meet meeting

### DIFF
--- a/static/calendar.css
+++ b/static/calendar.css
@@ -14,6 +14,7 @@
     --cal-cell-today-disabled: #b0a8b9;
     --cal-primary: #443752;
     --cal-cover: #000000ad;
+    --cal-info-padding: 10px;
 
     font-size: 14px;
 }
@@ -122,7 +123,7 @@
     width: 300px;
     background-color: white;
     border: 1px solid black;
-    padding: 10px;
+    padding: var(--cal-info-padding);
     z-index: 999;
     word-wrap: break-word;
     white-space: normal;
@@ -138,6 +139,23 @@
     padding-right: 20px;
     margin: 0;
     text-align: unset;
+}
+
+#calendar #calendar-info #calendar-join-button {
+    display: block;
+    margin-top: 10px;
+    padding: 5px;
+    text-align: center;
+
+    /* width: 100% will spill over the right padding, so use ✨calc magic✨ */
+    width: calc(100% - var(--cal-info-padding));
+
+    background-color: var(--cal-primary);
+    color: white;
+}
+
+#calendar #calendar-info #calendar-join-button.hidden {
+    display: none;
 }
 
 #calendar #calendar-info #calendar-info-where, #calendar #calendar-info #calendar-info-when {

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -244,6 +244,14 @@ function displayInfoPanel(target, event) {
         `${event.when_human.start_time}–${event.when_human.end_time} ${event.when_human.long_start_date}`
     document.getElementById('calendar-info-where').innerText = event.location;
 
+    // If there's no "where", hide the line break between "when" and "where"
+    // so we don't have a useless break
+    if (!event.location || event.location.trim() == '') {
+        document.getElementById('calendar-info-br').style.display = 'none';
+    } else {
+        document.getElementById('calendar-info-br').style.display = 'initial';
+    }
+
     const desc = document.getElementById('calendar-info-description');
     desc.innerHTML = event.description;
     while (desc.firstChild.nodeName.toLowerCase() == "br") {

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -249,6 +249,16 @@ function displayInfoPanel(target, event) {
     while (desc.firstChild.nodeName.toLowerCase() == "br") {
         desc.removeChild(desc.firstChild);
     }
+
+    // Only show the "Join Meeting" box if there's a meeting to join, and set
+    // the correct href
+    const meetingButton = document.getElementById('calendar-join-button');
+    if (event.meeting_link) {
+        meetingButton.href = event.meeting_link;
+        meetingButton.classList.remove("hidden");
+    } else {
+        meetingButton.classList.add("hidden");
+    }
 }
 
 /**

--- a/templates/calendar.handlebars
+++ b/templates/calendar.handlebars
@@ -48,7 +48,7 @@
       <a href="javascript:closeInfoPanel()" aria-label="Close Event Info Panel" id="calendar-info-close">&times;</a>
       <h3 id="calendar-info-title"></h4>
       <b id="calendar-info-when"></b>
-      <br>
+      <br id="calendar-info-br">
       <b id="calendar-info-where"></b>
       <a href="#" id="calendar-join-button" class="hidden">Join Google Meet</a>
       <div id="calendar-info-description"></div>

--- a/templates/calendar.handlebars
+++ b/templates/calendar.handlebars
@@ -50,6 +50,7 @@
       <b id="calendar-info-when"></b>
       <br>
       <b id="calendar-info-where"></b>
+      <a href="#" id="calendar-join-button" class="hidden">Join Google Meet</a>
       <div id="calendar-info-description"></div>
     </div>
   </div>


### PR DESCRIPTION
If a calendar event has a Google Meet meeting associated with it, this PR adds a button to join that meeting to the calendar on the homepage.

This also fixes an issue where events with no location would have a weird-looking blank line compared with events with a location.

Currently:

![The AGM calendar event on the HackSoc homepage with no Google Meet join button, and an unnecessary gap](https://user-images.githubusercontent.com/3321773/111014057-efb84d00-8399-11eb-979b-2ba41ef8cd25.png)

This PR:

![The AGM calendar event on the HackSoc homepage with a Google Meet join button and the gap gone](https://user-images.githubusercontent.com/3321773/111014061-f9da4b80-8399-11eb-822f-122dc89f4c4a.png)

I'd appreciate opinions on styling! I went for a simple box-y look because that's what the rest of the calendar looks like, but if you have ideas then do shout.

----

Closes #105.