### PR TITLE
Update talks page with Summer 2021/21 talks, and close submissions

### DIFF
--- a/regular/talks.html
+++ b/regular/talks.html
@@ -10,10 +10,10 @@ title: Talks
 </p>
 <br>
 <h2>Summer Term 2020/21</h2>
-<h3><em>Talk In Which Matt Talks For 30 Minutes about Sonic the Hedgehog(tm)</em> by Matt Windsor</h3>
+<h3><em>Talk In Which Matt Talks For 30 Minutes about Sonic the Hedgehog™</em> by Matt Windsor</h3>
 <b>May 13th (Summer Week 4)</b>
 <p>
-<u>Abstract:</u> Sonic the Hedgehog(tm) turns 30 this year, as do I.  Alas, before 2021 I had never actually properly sat down and played a Sonic game.  In fact, I didn't even have a Mega Drive until the mid-10s.  Shocking, I know!
+<u>Abstract:</u> Sonic the Hedgehog™ turns 30 this year, as do I.  Alas, before 2021 I had never actually properly sat down and played a Sonic game.  In fact, I didn't even have a Mega Drive until the mid-10s.  Shocking, I know!
 </p>
 <p>
 In this talk, I'll deep dive into how I went from a washed-up Mario fan to a full-on second childhood with the blue blur, with a goal to become a Sonic CD speedrunner some time this millennium.  I'll try to convince you that, in 2021, Classic Sonic still holds up, and you should definitely try it.  If you try, you can do anything!  (I won't talk about modern Sonic, don't worry.)
@@ -21,7 +21,7 @@ In this talk, I'll deep dive into how I went from a washed-up Mario fan to a ful
 <p>
 May or may not contain Knuckles.
 </p>
-<h3><em>The Revised^7 Report on the Algorithmic Language Scheme</em> by Daphne Preston-Kendal</h3>
+<h3><em>The Revised<sup>7</sup> Report on the Algorithmic Language Scheme</em> by Daphne Preston-Kendal</h3>
 <b>May 27th (Summer Week 6)</b>
 <p>
 <u>Abstract:</u> Scheme is a small but influential dialect of the Lisp programming language which has been standardized in multiple more-or-less compatible versions since its creation in the late 1970s. After decades of being used almost exclusively in teaching and research (with some exceptions), Scheme is now in the throes of a second attempt to expand the standard language to make it practical for use in production environments, R7RS. This talk will give a brief overview of the history of Scheme standardization over the last five decades, compare the initial ‘small’ version of R7RS (intended to carry on the tradition of versions of Scheme intended for use in teaching, research, and embedded environments) to previous standard versions of Scheme and assess its success so far, and review current progress on the ‘Large’ version of the standard (which is intended to be practical for developing large, real-world applications) and the difficulties of standardizing a practical but usable version of ‘the world's most unportable programming language’.

--- a/regular/talks.html
+++ b/regular/talks.html
@@ -9,14 +9,51 @@ title: Talks
   Attending talks is a great way to get a diverse look at what a degree in computer science can be, whether it's more focused on industry or academia. 
 </p>
 <br>
-<h2>Spring Term 2020/21</h2>
-<h3><em>Can Concurrency Testing Be Liberated From The Litmus Style?</em> by Matt Windsor</h3>
+<h2>Summer Term 2020/21</h2>
+<h3><em>Talk In Which Matt Talks For 30 Minutes about Sonic the Hedgehog(tm)</em> by Matt Windsor</h3>
+<b>May 13th (Summer Week 4)</b>
+<p>
+<u>Abstract:</u> Sonic the Hedgehog(tm) turns 30 this year, as do I.  Alas, before 2021 I had never actually properly sat down and played a Sonic game.  In fact, I didn't even have a Mega Drive until the mid-10s.  Shocking, I know!
+</p>
+<p>
+In this talk, I'll deep dive into how I went from a washed-up Mario fan to a full-on second childhood with the blue blur, with a goal to become a Sonic CD speedrunner some time this millennium.  I'll try to convince you that, in 2021, Classic Sonic still holds up, and you should definitely try it.  If you try, you can do anything!  (I won't talk about modern Sonic, don't worry.)
+</p>
+<p>
+May or may not contain Knuckles.
+</p>
+<h3><em>The Revised^7 Report on the Algorithmic Language Scheme</em> by Daphne Preston-Kendal</h3>
+<b>May 27th (Summer Week 6)</b>
+<p>
+<u>Abstract:</u> Scheme is a small but influential dialect of the Lisp programming language which has been standardized in multiple more-or-less compatible versions since its creation in the late 1970s. After decades of being used almost exclusively in teaching and research (with some exceptions), Scheme is now in the throes of a second attempt to expand the standard language to make it practical for use in production environments, R7RS. This talk will give a brief overview of the history of Scheme standardization over the last five decades, compare the initial ‘small’ version of R7RS (intended to carry on the tradition of versions of Scheme intended for use in teaching, research, and embedded environments) to previous standard versions of Scheme and assess its success so far, and review current progress on the ‘Large’ version of the standard (which is intended to be practical for developing large, real-world applications) and the difficulties of standardizing a practical but usable version of ‘the world's most unportable programming language’.
+</p>
+<h3><em>Dispatches from the Computing Titanic</em> by Jacob Allen</h3>
+<b>June 10th (Summer Week 8)</b>
+<p>
+<u>Abstract:</u> Contrary to many jokes, computers are (on the whole) well behaved and predictable machines that do exactly what you ask them to. This is why it is so much more noteworthy when they do not do what they were asked to, or worse, do exactly what they were asked to but not what was wanted. No better is this shown in what have come to be known as "cursed" parts of computing, such as those shown in the "Cursed computer Iceberg Meme" (<a href="https://suricrasia.online/iceberg/">https://suricrasia.online/iceberg/</a>).
+</p>
+<p>
+Join me as, taking inspiration from sources like the "Cursed computer Iceberg Meme", I talk about some of my favourite "cursed" parts of computing! Less serious than my previous talks this talk will focus on some of the more interesting and unexpected areas of "cursed" computing I've come across, and I will attempt to explain why some aren't quite as bad as you'd think, or why some are worse!
+</p>
+<h3><em>How Robot Swarms Can Help Solve Hard Problems</em> by C Wringe</h3>
+<b>June 24th (Summer Week 10)</b>
+<p>
+<u>Abstract:</u> Some tasks are too difficult for most robots to complete. And yet, insects perform them with apparent ease.
+</p>
+<p>
+Enter the biologically inspired robot swarm: A group of robots, individually performing simple tasks to create a more complex whole.
+</p>
+<p>
+In this talk, I will go over what a robot swarm is, and the sorts of problems they can solve. I will show what it means for a robot swarm to be scalable, flexible, and robust. Finally, I will go into some of the challenges faced by the field, and areas of current and future work.
+</p>
+<h2>Past talks</h2>
+<h3>Spring Term 2020/21</h3>
+<h4><em>Can Concurrency Testing Be Liberated From The Litmus Style?</em> by Matt Windsor</h4>
 <b>February 4th (Spring Week 4)</b>
 <p>
 <u>Abstract:</u> The 'litmus test' is a de facto standard for lightweight tests of concurrent systems, packaging shared state, initial values, expected final values, and thread bodies into a concise and readable format.  In this talk, I discuss litmus tests, how they are used in testing, the challenges of using them in compiler fuzz testing, and experimental attempts to overcome those challenges.
 </p>
 <br>
-<h3><em>How Robot Swarms Can Help Solve Hard Problems</em> by C Wringe</h3>
+<h4><em>How Robot Swarms Can Help Solve Hard Problems</em> by C Wringe</h4>
 <b>February 25th (Spring Week 7)</b>
 <p>
 <b><em>This talk will not take place this term. We apologise for the inconvenience and are trying to reschedule it.</em></b>
@@ -29,7 +66,7 @@ Enter the biologically inspired robot swarm: A group of robots, individually per
 <p>
 In this talk, I will go over what a robot swarm is, and the sorts of problems they can solve. I will show what it means for a robot swarm to be scalable, flexible, and robust. Finally, I will go into some of the challenges faced by the field, and areas of current and future work.
 </p>
-<h3><em>An Introduction to Constraint Programming</em> by Jacob Allen</h3>
+<h4><em>An Introduction to Constraint Programming</em> by Jacob Allen</h4>
 <b>March 25th (Spring Week 11)</b>
 <p>
 <u>Abstract:</u> As a programmer, computer scientist, computer engineer etc. there are many problems for which an algorithm can easily be determined or pulled from a text book, however, there is a class (or really two classes) of problems for which there are rarely such simple solutions: constraint problems. Luckily there exist powerful constraint programming tools to allow us to solve constraint problems using relatively simple concepts which often mirror how humans would solve the tasks.
@@ -37,7 +74,7 @@ In this talk, I will go over what a robot swarm is, and the sorts of problems th
 <p>
 In this talk I will introduce constraint programming and demonstrate how it can be used to solve complex problems efficiently, I will also show some examples of constraint solving programs and outline the simple underlying process by which they work.
 </p>
-<h2>Past talks</h2>
+<br/>
 <h3>Autumn Term 2020/21</h3>
 <h4><em>Mapping with Robots</em> by Jacob Allen</h4>
 <b>October 22nd (Autumn Week 4)</b>
@@ -266,7 +303,7 @@ This talk will explore the reasons behind this power difference, and maybe even 
 <h2>Giving a talk</h2>
 <br>
 <div class="noticebox">
-  If you'd like to give a talk in Summer Term, then please fill in <a href="https://forms.gle/2sALxgRiTDNSPEhu8">this Google form</a>. Submissions will close on the <b>12th of April</b>.
+  Submissions for talks are now closed.
 </div>
 <p>
   <a href="https://forms.gle/N95yNoonXnTQmgyL7">Subscribe to our mailing list</a> to receive our weekly newsletter and be notified when they open again!


### PR DESCRIPTION
Adds the four talks taking place this Summer term, and removes the submission link.