### PR TITLE
Add links to Libera Chat's webchat

### DIFF
--- a/news/2021-05-25-moving-to-libera.md
+++ b/news/2021-05-25-moving-to-libera.md
@@ -13,13 +13,16 @@ the same way as the current Freenode channel is.
 #cs-york also has a channel on Libera Chat, with the same people as 
 usually hang out there. 
 
-Libera Chat does not yet have a webchat. If you haven't got an irc 
-client, then we recommend using [The Lounge][thelounge]. This does 
-not require any special program. If you want an account, please 
-contact us at [hack@yusu.org](mailto:hack@yusu.org), or poke the 
-infrastructure officer. 
+<del>Libera Chat does not yet have a webchat.</del> <ins>Update: this is
+no longer true! You can access the webchat [at this
+link][webchat].</ins> If you haven't got an irc client, then we
+recommend using [The Lounge][thelounge]. This does not require any
+special program. If you want an account, please contact us at
+[hack@yusu.org](mailto:hack@yusu.org), or poke the infrastructure
+officer. 
 
 [summary]: 
 https://gist.github.com/aaronmdjones/1a9a93ded5b7d162c3f58bdd66b8f491
 [libera]: https://libera.chat/
 [thelounge]: https://thelounge.hacksoc.org/
+[webchat]: https://web.libera.chat/?channel=#hacksoc

--- a/regular/about.html
+++ b/regular/about.html
@@ -28,7 +28,7 @@ title: About Us
   <dt>Slack</dt>
   <dd><a href="https://hacksoc-york.slack.com">Join our Slack</a> with your york.ac.uk address</dd>
   <dt>IRC</dt>
-  <dd><a href="https://kiwiirc.com/client/libera.chat/hacksoc">#hacksoc on irc.libera.chat</a></dd>
+  <dd><a href="https://web.libera.chat/?channel=#hacksoc">#hacksoc on irc.libera.chat</a></dd>
 
   <dt>Facebook</dt>
   <dd><a href="https://www.facebook.com/groups/hacksoc">facebook.com/groups/hacksoc</a></dd>

--- a/regular/irc.html
+++ b/regular/irc.html
@@ -8,7 +8,7 @@ title: Slack and IRC
   <h3>Slack</h3>
   <p>You can join the chat <a href="https://hacksoc-york.slack.com/signup">on Slack</a> with your @york.ac.uk email address. Or email <a href="mailto:hack@yusu.org">hack@yusu.org</a> to request access.</p>
   <h3>IRC</h3>
-  <p>We have an IRC channel, connected to Slack. You can join the chat at <strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>.</p>
+  <p>We have an IRC channel, connected to Slack. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
   <h3>Discord</h3>
   <p>We also have a Discord server, used mostly for events, but a small number of channels are bridged from Slack. You can join using <a href="https://discord.gg/BFJDdyU">this link</a>.</p>
 </div>
@@ -17,7 +17,7 @@ title: Slack and IRC
 <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
 <ol>
-  <li>You don't need a special program: see <a href="https://thelounge.hacksoc.org/">The Lounge</a> (contact the infrastructure officer or email <a href="mailto:hack@yusu.org">hack@yusu.org</a> for an account)</li>
+  <li>You don't need a special program: see the <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a></li>
 
   <li>You don't talk to individuals on a contact list, you join channels: a group of people talking about the same topic.</li>
 
@@ -26,6 +26,6 @@ title: Slack and IRC
   <li>You can change your name with <code>/nick new_name</code>, and join a new channel with <code>/join #channel_name</code></li>
 </ol>
 
-<p>There is also the #cs-york channel, also on <a href="https://libera.chat/">Libera Chat</a>. This is not HackSoc's channel, but it is a great place to chat about CS stuff. Many HackSoc members also hang around there.</p>
+<p>There is also the #cs-york channel, also on <a href="https://web.libera.chat/?channel=#cs-york">on Libera Chat</a>. This is not HackSoc's channel, but it is a great place to chat about CS stuff. Many HackSoc members also hang around there.</p>
 
 <p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in the topic of #general in Slack).</p>


### PR DESCRIPTION
until recently libera had no webchat; this readds the links in the places they used to be before #151 and #152.