### PR TITLE
Run unit tests automatically with github actions

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,0 +1,20 @@
+name: Unit tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - name: "Create virtualenv"
+        run: python3 -m venv venv/
+      - name: "Install dependencies"
+        run: venv/bin/pip install -r pip-requirements.txt
+      - name: "Run unit tests"
+        run: venv/bin/python -m unittest discover -s tests/

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -23,7 +23,11 @@ jobs:
         run: python -m venv venv/
       - run: Get-ChildItem -Recurse
       - run: ls venv/bin
+      - name: "Activate virtualenv"
+        run: venv/Scripts/Activate.ps1
       - name: "Install dependencies"
-        run: venv/bin/pip install -r pip-requirements.txt
+        # run: venv/bin/pip install -r pip-requirements.txt
+        run: pip install -r pip-requirements.txt
       - name: "Run unit tests"
-        run: venv/bin/python -m unittest discover -s tests/
+        # run: venv/bin/python -m unittest discover -s tests/
+        run: python -m unittest discover -s tests/

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -22,7 +22,6 @@ jobs:
       - name: "Create virtualenv"
         run: python -m venv venv/
       - run: Get-ChildItem -Recurse
-      - run: ls venv/bin
       - name: "Activate virtualenv"
         run: venv/Scripts/Activate.ps1
       - name: "Install dependencies"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,7 +8,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
         py_ver: ["3.7", "3.8", "3.9"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -9,8 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        # py_ver: ["3.7", "3.8", "3.9"]
-        py_ver: ["3.7"]
+        py_ver: ["3.7", "3.8", "3.9"]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -28,7 +28,7 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
 
       - name: "Activate virtualenv"
-        run: venv/bin/activate
+        run: source venv/bin/activate
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
 
       - name: "Install dependencies"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -19,8 +19,9 @@ jobs:
         with:
           python-version: ${{ matrix.py_ver }}
       - run: ls ${{ env.pythonLocation }}
+      - run: python --version
       - name: "Create virtualenv"
-        run: python3 -m venv venv/
+        run: python -m venv venv/
       - name: "Install dependencies"
         run: venv/bin/pip install -r pip-requirements.txt
       - name: "Run unit tests"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py_ver }}
-      - run: ls ${{ env.pythonLocation }}
       - run: python --version
+      - run: ls venv/bin
       - name: "Create virtualenv"
         run: python -m venv venv/
       - name: "Install dependencies"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,14 +8,17 @@ jobs:
   unittest:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        py_ver: ["3.7", "3.8", "3.9"]
+        # os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest]
+        # py_ver: ["3.7", "3.8", "3.9"]
+        py_ver: ["3.7"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py_ver }}
+      - run: ls ${{ env.pythonLocation }}
       - name: "Create virtualenv"
         run: python3 -m venv venv/
       - name: "Install dependencies"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,7 +8,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         py_ver: ["3.7", "3.8", "3.9"]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -21,6 +21,7 @@ jobs:
       - run: python --version
       - name: "Create virtualenv"
         run: python -m venv venv/
+      - run: Get-ChildItem -Recurse
       - run: ls venv/bin
       - name: "Install dependencies"
         run: venv/bin/pip install -r pip-requirements.txt

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -2,6 +2,9 @@ name: Unit tests
 
 on:
   push:
+    branches:
+      - "master"
+      - "main"
   pull_request:
 
 jobs:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -6,12 +6,16 @@ on:
 
 jobs:
   unittest:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        py_ver: ["3.7", "3.8", "3.9"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7"
+          python-version: ${{ matrix.py_ver }}
       - name: "Create virtualenv"
         run: python3 -m venv venv/
       - name: "Install dependencies"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -19,9 +19,9 @@ jobs:
         with:
           python-version: ${{ matrix.py_ver }}
       - run: python --version
-      - run: ls venv/bin
       - name: "Create virtualenv"
         run: python -m venv venv/
+      - run: ls venv/bin
       - name: "Install dependencies"
         run: venv/bin/pip install -r pip-requirements.txt
       - name: "Run unit tests"

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -8,25 +8,31 @@ jobs:
   unittest:
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [windows-latest]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
         # py_ver: ["3.7", "3.8", "3.9"]
         py_ver: ["3.7"]
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py_ver }}
-      - run: python --version
+
       - name: "Create virtualenv"
         run: python -m venv venv/
-      - run: Get-ChildItem -Recurse
+
       - name: "Activate virtualenv"
         run: venv/Scripts/Activate.ps1
+        if: ${{ matrix.os == 'windows-latest' }}
+
+      - name: "Activate virtualenv"
+        run: venv/bin/activate
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
+
       - name: "Install dependencies"
-        # run: venv/bin/pip install -r pip-requirements.txt
         run: pip install -r pip-requirements.txt
+
       - name: "Run unit tests"
-        # run: venv/bin/python -m unittest discover -s tests/
         run: python -m unittest discover -s tests/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 HackSoc.org
 ===
 
+![Unit test status badge](https://github.com/hacksoc/hacksoc.org/actions/workflows/unittest.yaml/badge.svg)
+
 This build system is written in Python, [Flask](https://flask.palletsprojects.com/en/2.0.x/) and [Jinja](https://jinja.palletsprojects.com/en/3.0.x/). It replaces the [previous system][tag-previous] which used Node.js and [Handlebars](https://handlebarsjs.com/), in turn replacing the [system before it][tag-hackyll] based on Haskell and [Hakyll](https://jaspervdj.be/hakyll/).
 
 ## Documentation

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,5 +1,5 @@
 # Tests
-Tests are written with Python's builtin [`unittest`][https://docs.python.org/3/library/unittest.html] library. If you can come up with more helpful tests, please do!
+Tests are written with Python's builtin [`unittest`](https://docs.python.org/3/library/unittest.html) library. If you can come up with more helpful tests, please do!
 
 ## Test methodology
 Currently supported platforms include:
@@ -22,3 +22,6 @@ python -m unittest discover -s tests/
 venv/bin/python -m unittest discover -s tests/
 # otherwise
 ```
+
+## GitHub actions
+A workflow is [set up](../.github/workflows/unittest.yaml) to run the test suite (as above) on all operating systems and Python versions listed above.


### PR DESCRIPTION
**Recommend squash and merge**

This adds a workflow that will run the unit test suite on all platforms and Python versions. It should only run on new commits to `master`, and on currently open pull requests. This doesn't use self-hosted Action runners, so there is a minimal security risk.