### PR TITLE
Add redirects for Slack, newsletter, and Discord

### DIFF
--- a/docs/creating_modifying_complex_pages.md
+++ b/docs/creating_modifying_complex_pages.md
@@ -80,6 +80,8 @@ Page redirects are implemented by setting the `redirect` variable. Note that if 
 {% set redirect="/coc.html" %}
 ```
 
+Some pages in the site, such as `newsletter.html`, are provided as redirects which we can print on posters or other media. These aren't linked to within the site itself, so we must tell the freezer about them. If you add a page like this, you should also add its relative link to the list in the `get_redirect_page_routes` function of `freeze.py`.
+
 
 
 [jinjadocs]: https://jinja.palletsprojects.com/en/3.0.x/templates/ "Template designer documentation - Jinja Documentation (3.0.x)"

--- a/hacksoc_org/freeze.py
+++ b/hacksoc_org/freeze.py
@@ -73,6 +73,24 @@ def get_server_page_routes() -> Generator[str, None, None]:
         # see `get_static_routes`
 
 
+@freezer.register_generator
+def get_redirect_page_routes() -> Generator[str, None, None]:
+    """Yields URL routes for pages which exist solely to redirect. We use these similarly to a URL
+    shortener, providing nicer URLs to print or distribute.
+
+    This generator wouldn't be necessary if we used these links from our About pages, but that
+    would add an unnecessary redirect in the middle when coming from those pages.
+    
+    Yields:
+        Generator[str, None, None]: URL routes
+    """
+    yield from [
+        "/newsletter.html",
+        "/slack.html",
+        "/discord.html"
+    ]
+
+
 def freeze():
     """this seemingly useless method is used to provide a stable API if the freeze provider changes
     in the future

--- a/templates/content/discord.html.jinja2
+++ b/templates/content/discord.html.jinja2
@@ -1,0 +1,3 @@
+{% extends "base.html.jinja2" %}
+
+{% set redirect="https://discord.com/invite/cb3XweNhYs" %}

--- a/templates/content/newsletter.html.jinja2
+++ b/templates/content/newsletter.html.jinja2
@@ -1,0 +1,3 @@
+{% extends "base.html.jinja2" %}
+
+{% set redirect=mailing_list_signup %}

--- a/templates/content/slack.html.jinja2
+++ b/templates/content/slack.html.jinja2
@@ -1,0 +1,3 @@
+{% extends "base.html.jinja2" %}
+
+{% set redirect="https://hacksoc-york.slack.com/signup" %}


### PR DESCRIPTION
Added a few pages which simply redirect to our most-used external things, which otherwise have bulky links:

- Newsletter
- Slack
- Discord

(I've omitted Twitter since the full link for this is already short and looks nice.)

These aren't used within the site, since that would add an extra redirecting message for the user if they clicked on one of these links from e.g. the About page. So that the Flask freezer sees them, I've also added a new freeze generator named `get_redirect_page_routes` and documented its use.

(Note: We may tweak the server config to allow these particular redirects to be accessed without the .html extension.)