### PR TITLE
Add more Markdown backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,5 +102,5 @@ Exceptions to this license include the fonts in `static/fonts`, which are licens
 
 The Bytemark name and logo (`static/images/bytemark.png`) are registered trademarks of Bytemark Limited.
 
-[tag-previous]: https://github.com/HackSoc/hacksoc.org/tree/08694ad0fd706c4ff4580303a97031452d73772d
+[tag-previous]: https://github.com/HackSoc/hacksoc.org/tree/node-last
 [tag-hackyll]: https://github.com/HackSoc/hacksoc.org/tree/hakyll-last

--- a/hacksoc_org/__init__.py
+++ b/hacksoc_org/__init__.py
@@ -14,6 +14,9 @@ from os import path
 app = flask.Flask(__name__, static_folder=None, template_folder=None)
 # these folders are defined in the Blueprint anyway
 app.config["TEMPLATES_AUTO_RELOAD"] = True
+app.config["ENV"] = "development"
+app.config["DEBUG"] = True
+
 
 app.jinja_env.add_extension("jinja2.ext.do")
 # adds support for the jinja "do" statement

--- a/hacksoc_org/cli.py
+++ b/hacksoc_org/cli.py
@@ -50,7 +50,13 @@ SUBCOMMANDS
 
     parser.add_argument(
         "--markdown",
-        choices=["markdown2", "cmark", "commonmark", "mistletoe"],
+        choices=[
+            "markdown2",
+            "cmark",
+            "commonmark",
+            "mistletoe",
+            "markdown-it",
+        ],
         default="markdown2",
         help="Markdown backend to use (default markdown2)",
     )

--- a/hacksoc_org/cli.py
+++ b/hacksoc_org/cli.py
@@ -50,7 +50,7 @@ SUBCOMMANDS
 
     parser.add_argument(
         "--markdown",
-        choices=["markdown2", "cmark"],
+        choices=["markdown2", "cmark", "commonmark", "mistletoe"],
         default="markdown2",
         help="Markdown backend to use (default markdown2)",
     )

--- a/hacksoc_org/markdown.py
+++ b/hacksoc_org/markdown.py
@@ -42,13 +42,43 @@ class CmarkgfmMD(AbstractMarkdown):
         import cmarkgfm
 
         self.cmarkgfm = cmarkgfm
+        self.options = cmarkgfm.Options.CMARK_OPT_UNSAFE
 
     def render_markdown(self, markdown_src: str) -> str:
-        return self.cmarkgfm.github_flavored_markdown_to_html(markdown_src)
+        return self.cmarkgfm.github_flavored_markdown_to_html(markdown_src, self.options)
+
+
+class CommonMarkMD(AbstractMarkdown):
+    def __init__(self) -> None:
+        import commonmark
+
+        self.parser = commonmark.Parser()
+        self.renderer = commonmark.HtmlRenderer()
+
+    def render_markdown(self, markdown_src: str) -> str:
+        ast = self.parser.parse(markdown_src)
+        return self.renderer.render(ast)
+
+
+class MistletoeMD(AbstractMarkdown):
+    def __init__(self) -> None:
+        import mistletoe
+
+        # code highlighting is possible with Pygments
+        self.renderer = mistletoe.HTMLRenderer()
+        self.Document = mistletoe.Document
+
+    def render_markdown(self, markdown_src: str) -> str:
+        return self.renderer.render(self.Document(markdown_src))
 
 
 def get_markdown_cls():
-    return {"markdown2": Markdown2MD, "cmark": CmarkgfmMD}[app.config[CFG_MARKDOWN_IMPL]]
+    return {
+        "markdown2": Markdown2MD,
+        "cmark": CmarkgfmMD,
+        "commonmark": CommonMarkMD,
+        "mistletoe": MistletoeMD,
+    }[app.config[CFG_MARKDOWN_IMPL]]
 
 
 _markdowner = None

--- a/hacksoc_org/markdown.py
+++ b/hacksoc_org/markdown.py
@@ -72,12 +72,23 @@ class MistletoeMD(AbstractMarkdown):
         return self.renderer.render(self.Document(markdown_src))
 
 
+class MarkdownItMD(AbstractMarkdown):
+    def __init__(self) -> None:
+        import markdown_it
+
+        self.md = markdown_it.MarkdownIt().enable("table")
+
+    def render_markdown(self, markdown_src: str) -> str:
+        return self.md.render(markdown_src)
+
+
 def get_markdown_cls():
     return {
         "markdown2": Markdown2MD,
         "cmark": CmarkgfmMD,
         "commonmark": CommonMarkMD,
         "mistletoe": MistletoeMD,
+        "markdown-it": MarkdownItMD,
     }[app.config[CFG_MARKDOWN_IMPL]]
 
 

--- a/init-venv.sh
+++ b/init-venv.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-python3 -m venv venv/
-source venv/bin/activate
-pip install --upgrade -r pip-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ install_requires =
     cmarkgfm
     commonmark
     mistletoe
-    # markdown-it-py
+    markdown-it-py
 
 [options.entry_points]
 console_scripts = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,10 @@ install_requires =
     black
     markdown2
     cmarkgfm
+    commonmark
+    mistletoe
     # markdown-it-py
-    # mistletoe
-    # commonmark
 
 [options.entry_points]
 console_scripts = 
     hacksoc_org = hacksoc_org.cli:main
-
-# [options.extras_require]


### PR DESCRIPTION
Adds the following (CommonMark-compliant) Markdown backends: 
- `cmark`
- `commonmark`
- `mistletoe`
- `markdown-it-py`

At some point in the future, the goal will be to switch to one of these (or another CommonMark implementation).

## TODO
 - [ ] Update documentation
     - The abstraction layer barely needs documenting; if someone wants to add docstrings to it they're welcome.
 - [ ] Get syntax highlighting working
     - For the time being, "offline" highlighting (eg with `Pygments`) is preferred to simply tagging `<pre>` blocks for a JavaScript-based highlighter to process on the client-side.
