### PR TITLE
Add extra dependency note for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ venv\Scripts\Activate.ps1
 
 pip install --upgrade pip
 pip install -e .
+
+# If and only if you are using an Apple Silicon-based Mac, you must also install a non-pre-built pygit2
+# (Requires Homebrew)
+brew install libgit2
+pip uninstall pygit2
+pip install pygit2 --no-binary :all:
 ```
 
 On existing installations, if Python throws `ModuleNotFoundError`s, try running `pip install -e .` again as additional dependencies may have been added since your original install.


### PR DESCRIPTION
pygit2 does not ship an ARM binary and tries to use the x86 one, which results in this error on an Apple Silicon chip:

> ImportError: dlopen(/Users/aaron/.asdf/installs/python/3.10.0/lib/python3.10/site-packages/pygit2/_pygit2.cpython-310-darwin.so, 0x0002): tried: '/Users/aaron/.asdf/installs/python/3.10.0/lib/python3.10/site-packages/pygit2/_pygit2.cpython-310-darwin.so' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/_pygit2.cpython-310-darwin.so' (no such file), '/usr/lib/_pygit2.cpython-310-darwin.so' (no such file)

This PR adds an extra note to the the dependency installation part of the README explaining how to fix the issue, by reinstalling pygit2 with `--no-binary`.