### PR TITLE
Switch to calling pip via python for self upgrade

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -33,7 +33,7 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'macOS-latest' }}
 
       - name: "Upgrade pip"
-        run: pip install --upgrade pip
+        run: python -m pip install --upgrade pip
 
       - name: "Install package"
         run: pip install -e .

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -36,7 +36,7 @@ jobs:
         run: python -m pip install --upgrade pip
 
       - name: "Install package"
-        run: pip install -e .
+        run: python -m pip install -e .
 
       - name: "Run unit tests"
         run: python -m unittest discover -s tests/


### PR DESCRIPTION
On Windows the pip self upgrade fails. This is likely because it's replacing the in use executable which works on *nix but not Windows. I can't actually test this ahead of time as the action isn't an "on demand" action so this PR must exist to test it.

Fixes #184