### PR TITLE
cli.py: Added missing positional argument to `serve()`

### DIFF
--- a/hacksoc_org/cli.py
+++ b/hacksoc_org/cli.py
@@ -1,10 +1,11 @@
 from typing import Callable, Dict
-from hacksoc_org import app
+from hacksoc_org import app, ROOT_DIR
 from hacksoc_org.consts import *
 from hacksoc_org.freeze import freeze
 from hacksoc_org.serve import serve
 
 import argparse
+from os import path
 
 subcommand_handlers: Dict[str, Callable] = {}
 
@@ -76,7 +77,7 @@ def do_freeze():
 def do_serve():
     freeze()
     print()
-    serve()
+    serve(path.join(ROOT_DIR, "build"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Previously `hacksoc_org serve` would not work. This is fixed in this PR.


---


While running MyPy on the codebase would have revealed this bug, there would be too many false positives (apparent erroneous code that was in fact fine) to integrate this into automated testing. A test case to try running the `serve` command and halting it may be useful to expand the test coverage.