### PR TITLE
Convert shortcut reference links to collapsed reference links

### DIFF
--- a/templates/content/news/2019-01-10-new-servers.md
+++ b/templates/content/news/2019-01-10-new-servers.md
@@ -12,7 +12,7 @@ in the department, and decided to restore it and bring it back online.
 It took a new motherboard, power supply, and complement of hard drives,
 but we got it working!
 
-Around the same time, our friends at [Bytemark] were getting rid of
+Around the same time, our friends at [Bytemark][] were getting rid of
 some of their old servers, so we went down and bagged a couple. We
 ended up with a 16GB and a 32GB server, each with AMD quad-core CPUs.
 These took much less work to get ready to go.
@@ -23,17 +23,17 @@ forward to today, and all three are happily up, running, and ready for
 use. 
 
 ### Our new servers
-First up is [Latona]. Loaded with 4TB of drives in a RAID 6 array, it
+First up is [Latona][]. Loaded with 4TB of drives in a RAID 6 array, it
 will be a storage server for the society. Members can get a 
 **50GB share** on the server included with their membership - **check
 the [README][Latona] for details!**
 
-[Apollo] and [Diana] are our ex-Bytemark servers, and while members
+[Apollo][] and [Diana][] are our ex-Bytemark servers, and while members
 won't have accounts directly, they'll be used to host various services
 that members can use. One of those services which we're also launching
-today is [TheLounge], a web-based IRC client with some familiar
+today is [TheLounge][], a web-based IRC client with some familiar
 features if you've used Slack or Discord. Coupled with our IRC bouncer
-on [Runciman], this is a great way to keep up with society chat on
+on [Runciman][], this is a great way to keep up with society chat on
 `#hacksoc`, or check in with people over on `#cs-york`. Ask your
 infrastructure officer or email [hack@yusu.org](mailto:hack@yusu.org)
 for a free account.

--- a/templates/content/news/2019-02-14-agm.md
+++ b/templates/content/news/2019-02-14-agm.md
@@ -7,7 +7,7 @@ It's that time of the year again &ndash; AGM time!
 Our next AGM will be held at **7 pm in the Pod, on Friday, March 1st.**
 For anyone not in the know, the AGM is the Annual General Meeting, where we will elect the next full committee.
 
-In order for YUSU to recognise the vote, we must achieve quorum. This is **25% of all paid members**, so please do turn up and vote! If you cannot vote in person, then on the night we will be announcing nominations in [Slack] and will be accepting private messages with votes to either **kma** or **davidjn**.
+In order for YUSU to recognise the vote, we must achieve quorum. This is **25% of all paid members**, so please do turn up and vote! If you cannot vote in person, then on the night we will be announcing nominations in [Slack][] and will be accepting private messages with votes to either **kma** or **davidjn**.
 
 The positions available are:
  - **Chair**
@@ -22,7 +22,7 @@ The positions available are:
 The three Ordinary Members will be elected via the [Single Transferable Vote][stv] system, and the rest of the positions will be elected via the Alternative Vote system.
 
 It is very important that **Chair, Secretary and Treasurer** positions are filled, as without them, HackSoc is no more and will not be recognised by YUSU! So please, do consider running for these positions!  
-If you have any questions please ask away on Slack or by [email].
+If you have any questions please ask away on Slack or by [email][].
 
 If you'd like to nominate yourself, please email your **name**, the **role(s)** you'd like to be nominated for, and a **short manifesto** to [hack@yusu.org][email]. You can also **nominate yourself on the night** for as many positions as you'd like.
 

--- a/templates/content/servers/diana.md
+++ b/templates/content/servers/diana.md
@@ -9,7 +9,7 @@ Diana is a general-purpose server maintained by [HackSoc](https://www.hacksoc.or
 
 ## TheLounge &ndash; web-based IRC client
 *Homepage: [thelounge.chat][thelounge]*  
-TheLounge is an IRC client that works on desktop and mobile, for those who don't want to use WeeChat or irssi (or want a good client for Android/iOS). Its interface is familiar if you've used Slack or Discord, and has a number of neat features including image previews, emoji pickers for desktop, and push notifications for mentions.  While it does have some scrollback support, we'd recommend using ZNC on [runciman] to keep up-to-date with channels while you're away.  
+TheLounge is an IRC client that works on desktop and mobile, for those who don't want to use WeeChat or irssi (or want a good client for Android/iOS). Its interface is familiar if you've used Slack or Discord, and has a number of neat features including image previews, emoji pickers for desktop, and push notifications for mentions.  While it does have some scrollback support, we'd recommend using ZNC on [runciman][] to keep up-to-date with channels while you're away.  
 You can access TheLounge at [thelounge.hacksoc.org](https://thelounge.hacksoc.org). Message your [infrastructure officer][about] for an account.
 
 [thelounge]: https://thelounge.chat/

--- a/templates/content/servers/latona.md
+++ b/templates/content/servers/latona.md
@@ -19,7 +19,7 @@ Storing pornographic material or content that infringes copyright is stricly for
 **users must also be current members of the university.*
 
 ## Connecting
-Mounting shares is done over SSH. There is no shell access (for that, see [runciman] server).
+Mounting shares is done over SSH. There is no shell access (for that, see [runciman][] server).
 
 ### On-campus
 To connect on-campus, use the following command:
@@ -29,7 +29,7 @@ sshfs <hacksocuser>@latonahacksoc: <mountpoint>
 Where `<hacksocuser>` is your HackSoc username, and `<mountpoint>` is the folder on the local computer you want to mount your share to. This must be an empty directory. You may run into issues if you are using a computer managed by ITS (eg `csteach1` or a lab PC) and try to mount to a folder in your home directory, as your home directory itself is mounted from another server. The most robust method is to create a folder in `/tmp` to mount to, and then optionally create a symlink in your home directory.
 
 ### Off-campus
-Latona is hosted in the University Data Center, which means it is behind the campus firewall. In order to access it off-campus, use the uni [SSH service]. Once registered with the SSH service, you can use a command like the following to mount Latona.
+Latona is hosted in the University Data Center, which means it is behind the campus firewall. In order to access it off-campus, use the uni [SSH service][]. Once registered with the SSH service, you can use a command like the following to mount Latona.
 
 ```bash
 sshfs <hacksocuser>@latonahacksoc: <mountpoint> -o ProxyJump=<itsuser>@ssh.york.ac.uk 

--- a/templates/content/servers/runciman.md
+++ b/templates/content/servers/runciman.md
@@ -34,7 +34,7 @@ All users with a shell account have `~/public_html` and `~/private_html` directo
 This space is subject to the same disk quota as usual.
 
 ## IRC bouncer
-There is a [ZNC] server running on Runciman, speak to your Infrastructure Officer to get an account set up (available to all paying members). Connect from your IRC client via:
+There is a [ZNC][] server running on Runciman, speak to your Infrastructure Officer to get an account set up (available to all paying members). Connect from your IRC client via:
 - `irc.hacksoc.org:6667` - plaintext
 - `irc.hacksoc.org:7000` - SSL (recommended)
 


### PR DESCRIPTION
Support for shortcut reference links is spotty (in particular, they aren't supported in the markdown implementation used currently); collapsed reference links should work better.

this becomes kinda irrelevant once we switch markdown backends to something that supports commonmark, but also that's Pain and this is fast