### PR TITLE
Discord migration

### DIFF
--- a/docs/development_and_git.md
+++ b/docs/development_and_git.md
@@ -164,7 +164,7 @@ Your pull request may not be perfect, and might need some changes before it's me
 
 If someone replies to you disrespectfully or in a manner that otherwise breaches the Code of Conduct, you can:
  - email hack@yusu.org
- - contact a committee member on slack (in a channel or via a private message).
+ - ping the @Committee role on Discord or direct message one of its members
 
 ## 11. Making changes from feedback
 Once you've recieved feedback, you can follow the earlier steps: make changes, test, commit, push, and the new commit(s) will appear **in the same PR** &ndash; there's no need to delete your PR and create a new one. Once the reviewers are happy with your PR, they will merge it into the `main` branch.

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -27,8 +27,9 @@
     <dt>Email (Mailing List)</dt>
     <dd><a href="{{ mailing_list_signup }}">Subscribe</a></dd>
 
-    <dt>Slack</dt>
-    <dd><a href="https://hacksoc-york.slack.com">Join our Slack</a> with your york.ac.uk address</dd>
+    <dt>Discord</dt>
+    <dd><a href="https://discord.gg/Kmnw2a7TTq">Join our Discord</a></dd>
+
     <dt>IRC</dt>
     <dd><a href="https://web.libera.chat/?channel=#hacksoc">#hacksoc on irc.libera.chat</a></dd>
 
@@ -59,7 +60,7 @@
 
     <dt>Academic Events Officer</dt>
     <dd><em>vacant</em></dd>
-    
+
     <dt>Infrastructure Officer</dt>
     <dd>Adam Birtles, third year computer science undergraduate</dd>
 
@@ -67,6 +68,6 @@
     <dd>Ash Holland, fourth year computer science undergraduate</dd>
     <dd>Daniel Allinson, computer science undergraduate, currently on year in industry</dd>
     <dd><em>vacant</em></dd>
-    
+
   </dl>
 {% endblock body %}

--- a/templates/content/coc.html.jinja2
+++ b/templates/content/coc.html.jinja2
@@ -71,20 +71,20 @@
 </p>
 <h3>Bridging</h3>
 <p>
-    HackSoc’s primary chat platform is Slack. While it is not perfect, we have not yet found a suitable alternative. A summary of the alternatives as well as their pros and cons can be found <a href="https://wiki.hacksoc.org/wiki/Chat/Alternatives" target="_blank">here</a>. We additionally have two other main chat platforms, that are bridged to various channels on Slack.
+    HackSoc’s primary chat platform is Discord. It’s not perfect, but no platform is. A summary of the alternatives as well as their pros and cons can be found <a href="https://wiki.hacksoc.org/wiki/Chat/Alternatives" target="_blank">on our wiki</a>. We have two other chat platforms, Slack and IRC, that are bridged to various channels on Discord.
 </p>
 <p>
-    The HackSoc Discord server is primarily used for virtual events, although it is also frequently used by members as a way to hang out virtually outside of events. The bridged channels are: #general, #food, #bot-testing, and #gaming.
+    The HackSoc Slack workspace is primarily used by past members of HackSoc, but is still available to anyone who prefers its interface. The bridged channels are: #general, #random, #art, #cursed, #electronics, #f1, #food, #gaming, #music, #politics, #quotes, #wholesome, #bot-testing, and #discord-migration.
 </p>
 <p>
-    Additionally, we have a few IRC channels: irc#hacksoc is bridged to slack#general, irc#hacksoc-bottest is linked to slack#bot-testing, and irc#hacksoc-committee (a locked channel) is bridged to slack#committee (a private channel). These channels are mostly used by alumni, and also contain Mathison, a bot that makes things easier for people on irc, which can be found <a href="https://github.com/HackSoc/csbot" target="blank">here</a>.
+    Additionally, we have a few IRC channels: irc#hacksoc is bridged to discord#general, irc#hacksoc-bottest is bridged to discord#beep-boop, and irc#hacksoc-committee (a locked channel) is bridged to discord#committee-sensitive (a private channel). The IRC channels are mostly used by alumni, and also contain Mathison, a bot that makes things easier for people on IRC, the source code for which can be found <a href="https://github.com/HackSoc/csbot" target="blank">here</a>. (Note: Mathison’s messages won’t currently show up on platforms other than IRC.)
 </p>
 <p>
-    The bridging is done using <a href="https://github.com/sersorrel/sosig" target="_blank">sosig</a>. Because of the way we use them, messages in threads (that aren't <em>also</em> sent to channel) aren't bridged to other platforms.
+    The bridging is done using <a href="https://github.com/42wim/matterbridge" target="_blank">matterbridge</a>. Note: messages in threads aren't bridged to other platforms (apart from Slack thread messages which are also sent to channel).
 </p>
 <h3>Content Warnings</h3>
 <p>
-    When posting topics that might be sensitive or upsetting to some people, we like to use Slack’s threads as a type of content warning. The first message is the content warning in brackets, while the actual message would be in the thread replies.
+    When posting topics that might be sensitive or upsetting to some people, we like to use Discord’s spoiler tags as a type of content warning. The message starts with the content warning in brackets, and the actual message is written inside double pipe characters <code>||like this||</code>. When bridged to platforms that don’t support spoiler tags, text in spoiler tags will be removed and replaced with “[redacted]”.
 </p>
 <p>
     There is no hard rule about what topics should be CWed, but some topics you might want to consider warning for are:
@@ -97,22 +97,19 @@
 </ul>
 </p>
 <p>
-    Some topics that people might not want to deal with, like food or politics, have their own channels, and efforts should be made to keep those topics to those channels.
+    Some topics that people might not want to deal with, like food or politics, have their own channels, and efforts should be made to keep those topics to those channels. You can hide any Discord channel by muting it, then enabling “hide muted channels” in the server menu. Some channels (primarily #politics) are opt-in, and you’ll need a role to see them at all – to get access, check #welcome, or ask a committee member for help.
 </p>
 <p>
     It is helpful if CWs are fairly descriptive, as some people will want to know about, say, policies that might affect them personally, but not be able to deal with seeing random hate against them. For example, one might have the following CWs for transphobia:
 </p>
 <blockquote>
-    [reference to transphobic policy, funny]<br />
-    <i>a gallows humour tweet about a new policy</i>
+    [reference to transphobic policy, funny] ||<i>a gallows humour tweet about a new policy</i>||
 </blockquote>
 <blockquote>
-    [transphobic policy, new development]<br />
-    <i>a new update about said transphobic policy</i>
+    [transphobic policy, new development] ||<i>a new update about said transphobic policy</i>||
 </blockquote>
 <blockquote>
-    [transphobia, bad take]<br />
-    <i>a link to a bad tweet</i>
+    [transphobia, bad take] ||<i>a link to a bad tweet</i>||
 </blockquote>
 <p>
     When talking about a specific event, person or group, you may want to include them in the CW, like so:
@@ -124,17 +121,17 @@
     That said, if simply reposting a bad take, please consider whether it’s necessary - bear in mind that repeating lies (even by condemning them) makes it more likely that people will believe them, and the people affected by the take are quite likely to have already seen it. Also, there are certain topics that may be very traumatic to some people even if accompanied by a content warning, so think carefully whether it should be posted at all.
 </p>
 <p>
-    Some people choose to put ranting/talking about being upset behind content warnings. While this might be useful for some people, it is not a requirement, nor should be apologised for if one forgets to do it.
+    Some people choose to put ranting/talking about being upset in a thread. While this might be useful for some people, it is not a requirement, nor should it be apologised for if one forgets to do it.
 </p>
 <h3>IRC interlopers</h3>
 <p>
-    Sometimes people join our chat that may not be familiar with us, or may not be students at the University of York altogether. This can happen because anyone with an @york.ac.uk email can join the Slack, but also because anyone can join the IRC and our website is somehow one of the top Google results for “computer science irc”. Be nice and welcoming to them.
+    Sometimes people join our chat who may not be familiar with us, or may not be students at the University of York altogether. This can happen because anyone with an @york.ac.uk email can join the Slack (and anyone at all can join our Discord server), but particularly because anyone can join the IRC and our website is somehow one of the top Google results for “computer science irc”. Be nice and welcoming to them.
 </p>
 <p>
     Sometimes they may ask us to do their homework or ask an oddly specific CS question that’s clearly an assignment. Feel free to point them in the right direction, but consider not doing their homework for them. Not only can it be a violation of York’s academic misconduct policy or their institution’s honour code, but part of learning CS is learning how to solve problems, which someone solving it for you doesn’t teach. (Incidentally, if you’ve stumbled upon this page via Google, hi! Feel free to join and chat, but please don’t ask us to do your homework.)
 </p>
 <h3>Profiles</h3>
 <p>
-    Some people put their pronouns under “what I do” on Slack, or in their nickname on Discord. This is useful for others, but not required. Consider occasionally checking people’s profiles to see if their pronouns have changed.
+    Some people put their pronouns in their nickname or profile on Discord (NB: Discord profiles are not per-server, so change your nickname rather than your profile if you’d rather not out yourself to the world), or under “what I do” on Slack. This is useful for others, but not required. Consider occasionally checking people’s profiles to see if their pronouns have changed.
 </p>
 {% endblock body %}

--- a/templates/content/coc.html.jinja2
+++ b/templates/content/coc.html.jinja2
@@ -74,7 +74,7 @@
     HackSoc’s primary chat platform is Discord. It’s not perfect, but no platform is. A summary of the alternatives as well as their pros and cons can be found <a href="https://wiki.hacksoc.org/wiki/Chat/Alternatives" target="_blank">on our wiki</a>. We have two other chat platforms, Slack and IRC, that are bridged to various channels on Discord.
 </p>
 <p>
-    The HackSoc Slack workspace is primarily used by past members of HackSoc, but is still available to anyone who prefers its interface. The bridged channels are: #general, #random, #art, #cursed, #electronics, #f1, #food, #gaming, #music, #politics, #quotes, #wholesome, #bot-testing, and #discord-migration.
+    The HackSoc Slack workspace is primarily used by past members of HackSoc, but is still available to anyone who prefers its interface. The bridged channels are: #general, #random, #art, #cursed, #electronics, #f1, #food, #gaming, #music, #politics, #quotes, #wholesome, #bot-testing (to discord#beep-boop), and #discord-migration.
 </p>
 <p>
     Additionally, we have a few IRC channels: irc#hacksoc is bridged to discord#general, irc#hacksoc-bottest is bridged to discord#beep-boop, and irc#hacksoc-committee (a locked channel) is bridged to discord#committee-sensitive (a private channel). The IRC channels are mostly used by alumni, and also contain Mathison, a bot that makes things easier for people on IRC, the source code for which can be found <a href="https://github.com/HackSoc/csbot" target="blank">here</a>. (Note: Mathison’s messages won’t currently show up on platforms other than IRC.)

--- a/templates/content/coc.html.jinja2
+++ b/templates/content/coc.html.jinja2
@@ -5,13 +5,13 @@
 {% block body %}
 <h2>Values Statement</h2>
 <p>
-    HackSoc aims to be an inclusive space for all, and this code of conduct aims to reflect that. We are not able to cover every single behaviour in this code of conduct, so do not take it as a bullet pointed list of what you can and cannot do. Please follow the spirit of this code as well as the letter. 
+    HackSoc aims to be an inclusive space for all, and this code of conduct aims to reflect that. We are not able to cover every single behaviour in this code of conduct, so do not take it as a bullet pointed list of what you can and cannot do. Please follow the spirit of this code as well as the letter.
 </p>
 <p>
     If you see behaviour that is unacceptable and the person committing it doesn’t stop when asked, please reach out to a committee member, either in a channel or privately. (Your confidentiality will be respected if you reach out privately.)
 </p>
 <p>
-    We will not tolerate any use of this code of conduct as a hammer against marginalised people speaking out against harassment or microaggressions, or enforcing reasonable boundaries. 
+    We will not tolerate any use of this code of conduct as a hammer against marginalised people speaking out against harassment or microaggressions, or enforcing reasonable boundaries.
 </p>
 <h2>Rules</h2>
 <h3>General</h3>
@@ -50,6 +50,9 @@
         </ul>
     </li>
 </ul>
+</p>
+<p>
+    On our chat platforms, this code of conduct applies both to messages and to other information that is visible to our users. This includes profiles and statuses.
 </p>
 <h3>GitHub</h3>
 <p>
@@ -94,7 +97,7 @@
 </ul>
 </p>
 <p>
-    Some topics that people might not want to deal with, like food or politics, have their own channels, and efforts should be made to keep those topics to those channels.  
+    Some topics that people might not want to deal with, like food or politics, have their own channels, and efforts should be made to keep those topics to those channels.
 </p>
 <p>
     It is helpful if CWs are fairly descriptive, as some people will want to know about, say, policies that might affect them personally, but not be able to deal with seeing random hate against them. For example, one might have the following CWs for transphobia:

--- a/templates/content/index.html.jinja2
+++ b/templates/content/index.html.jinja2
@@ -33,7 +33,7 @@
 
     <div class="infobox">
     <h2>Virtual Games and Cake</h2>
-    <p>Join us in adapting our age-old Boardgames and Cake to a virtual setting in our Discord server, where we check in with each other and play games including Jackbox and Uno! Unfortunately, we can't bring and share cake, but we can make our own and post them on Slack.</p>
+    <p>Join us in adapting our age-old Boardgames and Cake to a virtual setting in our Discord server, where we check in with each other and play games including Jackbox and Uno! Unfortunately, we can't bring and share cake, but we can make our own and post them on Discord.</p>
     </div>
 
     <div class="infobox">

--- a/templates/content/irc.html.jinja2
+++ b/templates/content/irc.html.jinja2
@@ -14,7 +14,7 @@
     <p>We have an IRC channel, connected to our Discord's #general channel. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
   </div>
 
-  <p>Our chat system of choice is Discord. However, we've kept the option of using Slack or IRC by connecting our some of our Discord channels to channels on Slack and IRC. Note that, whilst a few channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
+  <p>Our chat system of choice is Discord. However, we've kept the option of using our legacy platforms of Slack and IRC. Note that, whilst a few channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
   <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
   <ol>

--- a/templates/content/irc.html.jinja2
+++ b/templates/content/irc.html.jinja2
@@ -1,20 +1,20 @@
 {% extends "base.html.jinja2" %}
 
-{% block title %}Slack and IRC{% endblock title %}
+{% block title %}Chat platforms{% endblock title %}
 
 {% block body %}
   <div class="noticebox">
     <h2>Want to join HackSoc? A good place to start is joining the chat!</h2>
     <p>Before joining, please read our <a href="{{url_for('.render_page', page='coc')}}">Code of Conduct</a>. If you want to know more about how we use our chat platforms, read through the Guidelines and Conventions on the same page.</p>
-    <h3>Slack</h3>
-    <p>You can join the chat <a href="https://hacksoc-york.slack.com/signup">on Slack</a> with your @york.ac.uk email address. Or email <a href="mailto:hack@yusu.org">hack@yusu.org</a> to request access.</p>
-    <h3>IRC</h3>
-    <p>We have an IRC channel, connected to Slack. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
     <h3>Discord</h3>
-    <p>We also have a Discord server, used mostly for events, but a small number of channels are bridged from Slack. You can join using <a href="https://discord.gg/BFJDdyU">this link</a>.</p>
+    <p>Our primary chat platform is Discord. You can join using <a href="https://discord.gg/Kmnw2a7TTq">this link</a>.</p>
+    <h3>Slack</h3>
+    <p>We also have a <a href="https://hacksoc-york.slack.com/signup">Slack workspace</a>, which is bridged to many of our Discord server's channels. You can join with your @york.ac.uk email address or email <a href="mailto:hack@yusu.org">hack@yusu.org</a> to request access.</p>
+    <h3>IRC</h3>
+    <p>We have an IRC channel, connected to our Discord's #general channel. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
   </div>
 
-  <p>Our chat system of choice is Slack. It's easy to use, fully-featured and modern. However, we've kept the option of using IRC by connecting our Slack channel to our IRC channel, and we have a Discord server set up in a similar way. Note that, whilst a couple of channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Slack</strong>.</p>
+  <p>Our chat system of choice is Discord. However, we've kept the option of using Slack or IRC by connecting our some of our Discord channels to channels on Slack and IRC. Note that, whilst a few channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
   <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
   <ol>
@@ -28,6 +28,4 @@
   </ol>
 
   <p>There is also the #cs-york channel, also on <a href="https://web.libera.chat/?channel=#cs-york">on Libera Chat</a>. This is not HackSoc's channel, but it is a great place to chat about CS stuff. Many HackSoc members also hang around there.</p>
-
-  <p>Our Discord server is mostly used for virtual events; you can join using <a href="https://discord.gg/BFJDdyU">this link</a> (there's also an invite link in the topic of #general in Slack).</p>
 {% endblock body %}

--- a/templates/content/servers/runciman.md
+++ b/templates/content/servers/runciman.md
@@ -6,7 +6,7 @@ name: Shell Server
 
 A plain-text version of this README can be found on `runciman.hacksoc.org:/README`.
 
-Runciman is a shell server maintained by [HackSoc](https://www.hacksoc.org) for the use of members of the society. 
+Runciman is a shell server maintained by [HackSoc](https://www.hacksoc.org) for the use of members of the society.
 
 ## Shell Accounts
 Shell accounts are only available for paid members of the society, in order to request one either speak to a member of the committee, or email [hack@yusu.org](mailto:hack@yusu.org)
@@ -30,7 +30,7 @@ All users with shell accounts are required to have read the Bytemark [Acceptable
 All users with a shell account have `~/public_html` and `~/private_html` directories:
  - `~/public_html`: https://runciman.hacksoc.org/~user/ , directory contents **are listed**
  - `~/private_html`: https://runciman.hacksoc.org/~/user/ , directory contents **not listed**
-  
+
 This space is subject to the same disk quota as usual.
 
 ## IRC bouncer
@@ -39,7 +39,7 @@ There is a [ZNC][] server running on Runciman, speak to your Infrastructure Offi
 - `irc.hacksoc.org:7000` - SSL (recommended)
 
 ## Minecraft server
-There is a vanilla Minecraft server (1.12.2) running on Runciman, connect on `runciman.hacksoc.org` (default port). If it's whitelisted, speak to your Infrastructure Officer or put a message in Slack.
+There is a vanilla Minecraft server (1.12.2) running on Runciman, connect on `runciman.hacksoc.org` (default port). If it's whitelisted, speak to your Infrastructure Officer or put a message in Discord.
 
 ## Scheduled downtime
 Runciman is scheduled to reboot at 4AM on the second Monday of each month. Services or tmuxes that you leave running will be killed, make sure they can come back up!

--- a/templates/nav.html.jinja2
+++ b/templates/nav.html.jinja2
@@ -8,7 +8,7 @@
     page: talks
   - text: github
     href: //www.github.com/HackSoc/
-  - text: slack/irc chat
+  - text: chat
     page: irc
   - text: twitter
     href: //twitter.com/HackSoc


### PR DESCRIPTION
As decided by the Committee, we're officially moving to Discord! This PR updates the website to reflect that change.

The most significant change is to the chat platforms page (templates/content/irc.html.jinja2). Additionally, various references and links to Slack on a few pages (and in some bits of documentation) have been replaced with Discord.

Additionally, this updates the Code of Conduct, which will soon be changed by HackSoc/constitution#23.

### Changes still needed

This PR is not quite ready to be merged. Some large changes to the Code of Conduct's Guidelines and Conventions section are still required:

- In general, the entire section needs to be changed to treat Discord as the primary platform.
- The Bridging subsection needs to be rewritten. It should:
  - Explain which channels on Discord are bridged to which channels on Slack and IRC.
    - Discord channels that are bridged say so in their descriptions.
    - The bridged channel’s name is only stated when it differs from the Discord channel’s name
  - Describe the behaviours of the new bridge.
- The Content Warnings subsection should specify how we will use them on Discord (spoilers).
- The Profiles subsection should specify that people are welcome to state their pronouns
  - The can add them to either their profiles and/or their nicknames. 
  - Server-specific profiles are a premium feature so they should use their server nickname if they don’t wish to be out to the entire world.
- It should probably  mention somewhere that Discord's channels are opt-out by default.
  - This can be done with muting.
  - The big exception is #politics, which is opt-in using a role.
