### PR TITLE
Correct about.html to reflect position renaming

### DIFF
--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -39,7 +39,7 @@
 
   <h2>Committee</h2>
 
-  <p>The HackSoc committee consists of a Chair, Secretary, and Treasurer who must all be students, furthermore, there is a Social Secretary, Academic Events Officer, Press and Publicity Officer, Infrastructure Officer, and 3 Ordinary Members.</p>
+  <p>The HackSoc committee consists of a Chair, Secretary, and Treasurer who must all be students, furthermore, there is a Press and Publicity Officer, Social Events Officer, Academic Events Officer, Infrastructure Officer, and 3 Ordinary Ordinary Officers.</p>
 
   <dl>
     <dt>Chair</dt>
@@ -51,12 +51,12 @@
     <dt>Treasurer</dt>
     <dd>Morgan McKay, fourth year computer science and maths undergraduate</dd>
 
-    <dt>Social Secretary</dt>
-    <dd><em>vacant</em></dd>
-
     <dt>Press and Publicity (position jointly held)</dt>
     <dd>Clara Hohenlohe, fourth year computer science undergraduate</dd>
     <dd>Jessica Russell, fourth year computer science undergraduate</dd>
+
+    <dt>Social Events Officer</dt>
+    <dd><em>vacant</em></dd>
 
     <dt>Academic Events Officer</dt>
     <dd><em>vacant</em></dd>


### PR DESCRIPTION
The change of Social Secretary to Social Events Officer (hacksoc/constitution#21) was apparently missed when last updating about.html. As was the paragraph describing the committee.

Additionally, I've moved Social Events Officer down to be next to Academic Events Officer in the list.