### PR TITLE
Update talks.html

### DIFF
--- a/templates/content/talks.html.jinja2
+++ b/templates/content/talks.html.jinja2
@@ -105,9 +105,9 @@ Talks
 
    When talk submissions close, change all variables to None (not in quotes).
   #}
-  {%- set submissions_form = "https://forms.gle/wbuS128SrUBCUTeK7" %}
-  {%- set submissions_term = "Autumn" %}
-  {%- set submissions_close = "2022-10-03" %}
+  {%- set submissions_form = None %}
+  {%- set submissions_term = None %}
+  {%- set submissions_close = None %}
 
   <div class="noticebox">
     {%- if submissions_form and submissions_term and submissions_close %}
@@ -123,7 +123,9 @@ Talks
   #} 
 
   <hr>
-  <h2>Spring Term 2021/22</h2>
+
+  <details open>
+  <summary><h2>Spring Term 2021/22</h2></summary>
   {%- set term="Spring" -%}
 
   {% call talk() %}
@@ -165,9 +167,9 @@ Talks
 
       Please note: this talk will not include any real life examples beyond abstract hypothetical scenarios.
   {% endcall %}
+  </details>
 
-
-  <details open>
+  <details>
   <summary><h2>Autumn Term 2021/22</h2></summary>
   {%- set term="Autumn" -%}
 


### PR DESCRIPTION
 * Remove talk submissions link (ended in Autumn 2022)
 * Move Spring 2022 talks into `<details>` section along with other past talks.