### PR TITLE
add new committee members 2025

### DIFF
--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -55,7 +55,7 @@
     <dd>Iris McBride, third year computer science undergraduate</dd>
 
     <dt>Academic Events Officer</dt>
-    <dd> Unfilled </dd>
+    <dd>Unfilled</dd>
 
     <dt>Infrastructure Officers (positions jointly held x2)</dt>
     

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -69,7 +69,7 @@
     <dd>Katelyn Burberry, first year computer science undergraduate</dd>
 
     <div style="display:None;">
-      <div>Shadow Committee
+       <div>Shadow Committee
           <dt>Brownie officer</dt>
           <dd>atlie</dd>
 

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -59,7 +59,7 @@
 
     <dt>Infrastructure Officers (positions jointly held x2)</dt>
     
-    <dd> Ashley Bryan, second year computer science undergraduate </dd>
+    <dd>Ashley Bryan, second year computer science undergraduate</dd>
     <br>
     <dd>Aaron Heald, second year computer science undergraduate</dd>
     <dd>Will Hall, second year computer science undergraduate</dd>

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -55,19 +55,15 @@
     <dd>Iris McBride, third year computer science undergraduate</dd>
 
     <dt>Academic Events Officer</dt>
-    <dd>Unfilled</dd>
+    <dd><em>vacant</em></dd>
 
     <dt>Infrastructure Officers (positions jointly held x2)</dt>
     
     <dd>Ashley Bryan, second year computer science undergraduate</dd>
-    <br>
     <dd>Aaron Heald, second year computer science undergraduate</dd>
     <dd>Will Hall, second year computer science undergraduate</dd>
-    <br>
     <dd>Ren Herring, second year computer science undergraduate</dd>
     <dd>Evelyn Gravett, second year computer science undergraduate</dd>
-    <br>
-    
     
     <dt>Ordinary Officer</dt>
     <dd>Katelyn Burberry, first year computer science undergraduate</dd>

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -68,5 +68,17 @@
     <dt>Ordinary Officer</dt>
     <dd>Katelyn Burberry, first year computer science undergraduate</dd>
 
+    <div style="display:None;">
+      <div>Shadow Committee
+          <dt>Brownie officer</dt>
+          <dd>atlie</dd>
+
+          <dt>Mario and Doom officer</dt>
+          <dd>Jess</dd>
+
+          <dt>filmbro</dt>
+          <dd>Clara</dd>
+       </div>
+    </div>
   </dl>
 {% endblock body %}

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -43,34 +43,34 @@
 
   <dl>
     <dt>Chair</dt>
-    <dd>Joe Krystek-Walton, third year computer science undergraduate</dd>
+    <dd>Aaron Heald, second year computer science undergraduate</dd>
 
-    <dt>Secretary (position jointly held)</dt>
-    <dd>Lily Amber, first year maths undergraduate</dd>
-    <dd>Leah Millar, first year computer science and maths undergraduate</dd>
+    <dt>Secretary </dt>
+    <dd>Will Hall, second year computer science undergraduate</dd>
 
     <dt>Treasurer</dt>
-    <dd>Nico Pendleton, first year philosophy undergraduate</dd>
+    <dd>Ren Herring, second year computer science undergraduate</dd>
 
     <dt>Social Events Officer</dt>
-    <dd>Lilly Brown, fourth year computer science undergraduate</dd>
+    <dd>Iris McBride, third year computer science undergraduate</dd>
 
     <dt>Academic Events Officer</dt>
-    <dd><em>vacant</em></dd>
+    <dd> Unfilled </dd>
 
-    <div style="display:None;">
-       <div>Shadow Committee
-          <dt>Brownie officer</dt>
-          <dd>atlie</dd>
-
-          <dt>Mario and Doom officer</dt>
-          <dd>Jess</dd>
-
-          <dt>filmbro</dt>
-          <dd>Clara</dd>
-       </div>
-    </div>
+    <dt>Infrastructure Officers (positions jointly held x2)</dt>
     
+    <dd> Ashley Bryan, second year computer science undergraduate </dd>
+    <br>
+    <dd>Aaron Heald, second year computer science undergraduate</dd>
+    <dd>Will Hall, second year computer science undergraduate</dd>
+    <br>
+    <dd>Ren Herring, second year computer science undergraduate</dd>
+    <dd>Evelyn Gravett, second year computer science undergraduate</dd>
+    <br>
+    
+    
+    <dt>Ordinary Officer</dt>
+    <dd>Katelyn Burberry, first year computer science undergraduate</dd>
 
   </dl>
 {% endblock body %}

--- a/templates/content/about.html.jinja2
+++ b/templates/content/about.html.jinja2
@@ -57,7 +57,7 @@
     <dt>Academic Events Officer</dt>
     <dd><em>vacant</em></dd>
 
-    <dt>Infrastructure Officers (positions jointly held x2)</dt>
+    <dt>Infrastructure Officers (position jointly held)</dt>
     
     <dd>Ashley Bryan, second year computer science undergraduate</dd>
     <dd>Aaron Heald, second year computer science undergraduate</dd>

--- a/templates/content/irc.html.jinja2
+++ b/templates/content/irc.html.jinja2
@@ -8,13 +8,11 @@
     <p>Before joining, please read our <a href="{{url_for('.render_page', page='coc')}}">Code of Conduct</a>. If you want to know more about how we use our chat platforms, read through the Guidelines and Conventions on the same page.</p>
     <h3>Discord</h3>
     <p>Our primary chat platform is Discord. You can join using <a href="https://discord.gg/Kmnw2a7TTq">this link</a>.</p>
-    <h3>Slack</h3>
-    <p>We also have a <a href="https://hacksoc-york.slack.com/signup">Slack workspace</a>, which is bridged to many of our Discord server's channels. You can join with your @york.ac.uk email address or email <a href="mailto:hack@yusu.org">hack@yusu.org</a> to request access.</p>
     <h3>IRC</h3>
     <p>We have an IRC channel, connected to our Discord's #general channel. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
   </div>
 
-  <p>Our chat system of choice is Discord. However, we've kept the option of using our legacy platforms of Slack and IRC. Note that, whilst a few channels are bridged between Discord, IRC, and Slack, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
+  <p>Our chat system of choice is Discord. However, we've kept the option of using our legacy platforms of IRC. Note that, whilst a few channels are bridged between Discord, IRC, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
   <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
   <ol>

--- a/templates/content/irc.html.jinja2
+++ b/templates/content/irc.html.jinja2
@@ -12,7 +12,7 @@
     <p>We have an IRC channel, connected to our Discord's #general channel. You can join the chat using Libera Chat's <a href="https://web.libera.chat/?channel=#hacksoc">webchat</a> (<strong>#hacksoc</strong> on <strong>irc.libera.chat</strong>).</p>
   </div>
 
-  <p>Our chat system of choice is Discord. However, we've kept the option of using our legacy platforms of IRC. Note that, whilst a few channels are bridged between Discord, IRC, there are plenty that aren't, and <strong>you'll miss out on most of the conversation if you're not on Discord</strong>.</p>
+  <p>Our chat system of choice is Discord. However, we've kept the option of using our old IRC channel too. Note that while the IRC channel is bridged to Discord, there are other channels that are only on Discord, and <strong>you'll miss out on most of the conversation if you're not on there</strong>.</p>
   <p>IRC, or Internet Relay Chat, is a protocol with a long and glorious history stretching back into the mists of time. It's a pretty simple system for online chatrooms, and you don't even need a special program to connect to it, although they do exist.</p>
 
   <ol>


### PR DESCRIPTION
This pull request updates the content of the website to reflect changes in committee roles and simplifies the description of chat platforms. The most important changes include updating committee member details and removing references to Slack as a supported chat platform.

### Updates to committee roles:
* Updated the `Chair`, `Secretary`, `Treasurer`, `Social Events Officer`, and `Academic Events Officer` roles with new members in `templates/content/about.html.jinja2`. Added new roles such as `Infrastructure Officers` and `Ordinary Officer` with their respective members.

### Simplification of chat platform descriptions:
* Removed references to Slack as a supported chat platform in `templates/content/irc.html.jinja2`, leaving Discord and IRC as the primary and legacy platforms, respectively. Updated the description to reflect this change.